### PR TITLE
Updating github action to v4

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,3 +1,4 @@
+name: Draft PDF
 on: [push]
 
 jobs:
@@ -14,7 +15,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: docs/paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled


### PR DESCRIPTION
To fix a failure in the github action for creating the JOSS draft paper. We need to update the version of `actions/upload-artifact` from v1 to v4.