### PR TITLE
Fix tiny bug printing the index of the experiment in the idealised flow example

### DIFF
--- a/docs/examples/example_idealised_flow.ipynb
+++ b/docs/examples/example_idealised_flow.ipynb
@@ -28,7 +28,10 @@
     "import parcels\n",
     "\n",
     "# Plotting imports\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
@@ -341,7 +344,7 @@
      "output_type": "stream",
      "text": [
       "INFO: Output files are stored in example_idealised_flow_experiment_1.zarr.\n",
-      "100%|██████████| 345600.0/345600.0 [00:38<00:00, 8911.29it/s]\n"
+      "100%|██████████| 345600.0/345600.0 [00:44<00:00, 7791.01it/s]\n"
      ]
     }
    ],
@@ -421,7 +424,7 @@
      "output_type": "stream",
      "text": [
       "INFO: Output files are stored in example_idealised_flow_experiment_2.zarr.\n",
-      "100%|██████████| 345600.0/345600.0 [00:47<00:00, 7258.52it/s]\n"
+      "100%|██████████| 345600.0/345600.0 [00:55<00:00, 6278.37it/s]\n"
      ]
     }
    ],
@@ -501,7 +504,7 @@
      "output_type": "stream",
      "text": [
       "INFO: Output files are stored in example_idealised_flow_experiment_3.zarr.\n",
-      "100%|██████████| 345600.0/345600.0 [00:55<00:00, 6218.34it/s]\n"
+      "100%|██████████| 345600.0/345600.0 [01:00<00:00, 5742.26it/s]\n"
      ]
     }
    ],
@@ -581,7 +584,7 @@
      "output_type": "stream",
      "text": [
       "INFO: Output files are stored in example_idealised_flow_experiment_4.zarr.\n",
-      "100%|██████████| 345600.0/345600.0 [00:49<00:00, 7013.46it/s]\n"
+      "100%|██████████| 345600.0/345600.0 [00:53<00:00, 6502.73it/s]\n"
      ]
     }
    ],
@@ -661,7 +664,7 @@
      "output_type": "stream",
      "text": [
       "INFO: Output files are stored in example_idealised_flow_experiment_5.zarr.\n",
-      "100%|██████████| 345600.0/345600.0 [01:07<00:00, 5152.07it/s]\n"
+      "100%|██████████| 345600.0/345600.0 [01:21<00:00, 4246.80it/s]\n"
      ]
     }
    ],
@@ -719,7 +722,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final depth range of particles in experiment 0: 557.2360 to 557.2360 m\n"
+      "Final depth range of particles in experiment 1: 557.2360 to 557.2360 m\n"
      ]
     },
     {
@@ -736,7 +739,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final depth range of particles in experiment 1: 0.0000 to 0.0000 m\n"
+      "Final depth range of particles in experiment 2: 0.0000 to 0.0000 m\n"
      ]
     },
     {
@@ -753,7 +756,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final depth range of particles in experiment 2: 554.3013 to 554.3013 m\n"
+      "Final depth range of particles in experiment 3: 554.3013 to 554.3013 m\n"
      ]
     },
     {
@@ -770,7 +773,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final depth range of particles in experiment 3: 557.2427 to 557.3295 m\n"
+      "Final depth range of particles in experiment 4: 557.2427 to 557.3295 m\n"
      ]
     },
     {
@@ -787,7 +790,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final depth range of particles in experiment 4: 557.2427 to 557.3296 m\n"
+      "Final depth range of particles in experiment 5: 557.2427 to 557.3296 m\n"
      ]
     }
    ],
@@ -815,7 +818,7 @@
     "    plt.title(f'Experiment {i+1}')\n",
     "    plt.show()\n",
     "\n",
-    "    print(f'Final depth range of particles in experiment {i}: {format(np.nanmin(pfile[\"z\"].values[:,-1]), '.4f')} to {format(np.nanmax(pfile[\"z\"].values[:,-1]), '.4f')} m')"
+    "    print(f'Final depth range of particles in experiment {i+1}: {format(np.nanmin(pfile[\"z\"].values[:,-1]), '.4f')} to {format(np.nanmax(pfile[\"z\"].values[:,-1]), '.4f')} m')"
    ]
   }
  ],
@@ -835,7 +838,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "undefined.undefined.undefined"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/docs/examples/example_idealised_flow.ipynb
+++ b/docs/examples/example_idealised_flow.ipynb
@@ -28,10 +28,7 @@
     "import parcels\n",
     "\n",
     "# Plotting imports\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "import warnings\n",
-    "warnings.filterwarnings(\"ignore\")"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {


### PR DESCRIPTION
This PR is to fix a tiny printing issue in the idealised flow example. The final block of code plots the positions of the particles and prints the depth range of the particles for each experiment. The plots have 'Experiment i+1', but the print statements show 'experiment i'.